### PR TITLE
make translations directories a set

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,22 @@ if defined?(Rodauth::I18n)
 end
 ```
 
+or when the feature has been loaded by `rodauth`:
+
+```rb
+module Rodauth
+  Feature.define(:my_feature, :MyFeature) do
+
+  # ...
+
+  def post_configure
+    super
+
+    Rodauth::I18n.directories << File.expand_path("#{__dir__}/../locales")
+  end
+end
+```
+
 ## Development
 
 Run tests with Rake:

--- a/lib/rodauth/i18n.rb
+++ b/lib/rodauth/i18n.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "set"
 require "i18n"
 require "rodauth/i18n/railtie" if defined?(Rails)
 
@@ -23,7 +24,7 @@ module Rodauth
     end
 
     def self.directories
-      @directories ||= [File.expand_path("#{__dir__}/../../locales")]
+      @directories ||= Set[File.expand_path("#{__dir__}/../../locales")]
     end
   end
 end


### PR DESCRIPTION
This makes injecting the same translations directory idempotent, thereby making the operation safe to use in a rodauth hook.