### PR TITLE
rails generator: take other rodauth plugin translations into account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "rails", ">= 4.2"
+gem "rodauth-rails"
+
 gem "rake", "~> 13.0"
 gem "rodauth", ">= 2.16"
 

--- a/lib/rodauth/features/i18n.rb
+++ b/lib/rodauth/features/i18n.rb
@@ -1,3 +1,4 @@
+require "set"
 require "i18n"
 
 module Rodauth
@@ -16,7 +17,7 @@ module Rodauth
       :i18n_locale,
     )
 
-    @i18n_files = []
+    @i18n_files = Set.new
 
     class << self
       attr_reader :i18n_files

--- a/lib/rodauth/features/i18n.rb
+++ b/lib/rodauth/features/i18n.rb
@@ -16,6 +16,12 @@ module Rodauth
       :i18n_locale,
     )
 
+    @i18n_files = []
+
+    class << self
+      attr_reader :i18n_files
+    end
+
     def post_configure
       super
       i18n_register File.expand_path("#{__dir__}/../../../locales")
@@ -76,6 +82,7 @@ module Rodauth
     # point, so we prepend built-in translations to the load path to ensure we
     # don't override them.
     def i18n_add(file)
+      I18n.i18n_files << file
       ::I18n.load_path.unshift(file) unless ::I18n.load_path.include?(file)
     end
 

--- a/test/feature_test.rb
+++ b/test/feature_test.rb
@@ -150,6 +150,18 @@ describe "i18n feature" do
     assert_equal I18n.load_path, I18n.load_path.uniq
   end
 
+  it "adds i18n files into a specific plugin global registry" do
+    rodauth do
+      enable :i18n
+    end
+
+    roda do |r|
+    end
+
+    en_file = File.expand_path(File.join(__dir__, "..", "locales", "en.yml"))
+    assert_includes Rodauth::I18n.i18n_files, en_file
+  end
+
   it "doesn't override previous translations" do
     tempfile = Tempfile.new ["", ".yml"]
     tempfile.write YAML.dump({ en: { rodauth: { login_label: "Email" } } })

--- a/test/generators/translations_generator_test.rb
+++ b/test/generators/translations_generator_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails"
+require "rodauth/rails"
+require_relative "../test_helper"
+require_relative "../rails_app/config/environment"
+require "generators/rodauth/translations_generator"
+
+class InstallGeneratorTest < Rails::Generators::TestCase
+  tests Rodauth::Rails::TranslationsGenerator
+  destination File.expand_path("#{__dir__}/../tmp")
+  setup :prepare_destination
+
+  test "locales" do
+    run_generator %w[en]
+
+    assert_file "config/locales/rodauth.en.yml" do |translations|
+      assert_match(/logout_button: Logout/, translations)
+    end
+  end
+end

--- a/test/rails_app/Rakefile
+++ b/test/rails_app/Rakefile
@@ -1,0 +1,3 @@
+require_relative "config/application"
+
+Rails.application.load_tasks

--- a/test/rails_app/app/controllers/application_controller.rb
+++ b/test/rails_app/app/controllers/application_controller.rb
@@ -1,0 +1,3 @@
+class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+end

--- a/test/rails_app/app/controllers/rodauth_controller.rb
+++ b/test/rails_app/app/controllers/rodauth_controller.rb
@@ -1,0 +1,2 @@
+class RodauthController < ApplicationController
+end

--- a/test/rails_app/app/misc/rodauth_app.rb
+++ b/test/rails_app/app/misc/rodauth_app.rb
@@ -1,0 +1,10 @@
+class RodauthApp < Rodauth::Rails::App
+  configure do
+    enable :i18n, :login
+    rails_controller { RodauthController }
+  end
+
+  route do |r|
+    r.rodauth
+  end
+end

--- a/test/rails_app/config/application.rb
+++ b/test/rails_app/config/application.rb
@@ -1,0 +1,20 @@
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "active_job/railtie"
+require "rails/test_unit/railtie"
+
+require "rodauth-rails"
+
+module RailsApp
+  class Application < Rails::Application
+    config.root = Pathname("#{__dir__}/..").expand_path
+    config.logger = Logger.new(nil)
+    config.eager_load = true
+    config.action_dispatch.show_exceptions = false
+    config.action_mailer.delivery_method = :test
+    config.action_mailer.default_url_options = { host: "example.com", protocol: "https" }
+    config.active_record.maintain_test_schema = false
+    config.active_record.legacy_connection_handling = false if ActiveRecord::VERSION::MAJOR >= 7
+  end
+end

--- a/test/rails_app/config/database.yml
+++ b/test/rails_app/config/database.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: sqlite3
+  database: ":memory:"

--- a/test/rails_app/config/database.yml
+++ b/test/rails_app/config/database.yml
@@ -1,3 +1,3 @@
 test:
-  adapter: sqlite3
+  adapter: <%= RUBY_ENGINE == 'jruby' ? 'jdbc:sqlite' : 'sqlite3' %>
   database: ":memory:"

--- a/test/rails_app/config/environment.rb
+++ b/test/rails_app/config/environment.rb
@@ -1,0 +1,3 @@
+require_relative "application"
+
+RailsApp::Application.initialize!

--- a/test/rails_app/config/initializers/rodauth.rb
+++ b/test/rails_app/config/initializers/rodauth.rb
@@ -1,0 +1,3 @@
+Rodauth::Rails.configure do |config|
+  config.app = "RodauthApp"
+end

--- a/test/rails_app/config/initializers/secret_key_base.rb
+++ b/test/rails_app/config/initializers/secret_key_base.rb
@@ -1,0 +1,1 @@
+Rails.application.secrets.secret_key_base = "a8457c8003e83577e92708bd56e19bdc4442c689f458f483a30e580611c578a3"

--- a/test/rails_app/config/routes.rb
+++ b/test/rails_app/config/routes.rb
@@ -1,0 +1,7 @@
+Rails.application.routes.draw do
+  root to: "test#root"
+
+  constraints Rodauth::Rails.authenticated do
+    get "/authenticated" => "test#root"
+  end
+end


### PR DESCRIPTION
In order to take rodauth plugin registered translations into account, the following is done:

1. store rodauth-only translation files in a global store
2. use it when generating the destinationn files

@janko I'm having an issue that requires your input. So, using generators might not cut it, as these do not load the application, so there's nothing in the registry to be picked up. This could alternatively be accomplished using a rails/rake task that loads the environment. Would that be an acceptable workaround, given that the cli interface would have to change?

Other suggestions are welcome.